### PR TITLE
[Refactor] 수강신청 API 및 연습 모드 코드 정리

### DIFF
--- a/src/api/registration.ts
+++ b/src/api/registration.ts
@@ -1,79 +1,28 @@
-import { api } from "./axios";
-import type { PracticeRegisterRequest } from "../types/apiTypes.tsx";
+import { api } from './axios';
+import type { PracticeRegisterRequest } from '../types/apiTypes.ts';
 
-export const practiceStartApi = async (
-  virtualStartTimeOption: string,
-) => {
-  return await api.post(
-    "/api/practice/start",
-    {
-      virtualStartTimeOption,
-    },
-    {
-      withCredentials: true,
-      headers: {
-        "Content-Type": "application/json",
-      },
-    },
-  );
+export const practiceStartApi = async (virtualStartTimeOption: string) => {
+  return await api.post('/api/practice/start', {
+    virtualStartTimeOption,
+  });
 };
 
 export const practiceEndApi = async () => {
-  return await api.post(
-    "/api/practice/end",
-    {},
-    {
-      withCredentials: true,
-      headers: {
-        "Content-Type": "application/json",
-      },
-    },
-  );
+  return await api.post('/api/practice/end');
 };
 
-export const practiceAttemptApi = async (
-  data: PracticeRegisterRequest,
-) => {
-  return await api.post(
-    "/api/practice/attempt",
-    data,
-    {
-      withCredentials: true,
-      headers: {
-        "Content-Type": "application/json",
-      },
-    },
-  );
+export const practiceAttemptApi = async (data: PracticeRegisterRequest) => {
+  return await api.post('/api/practice/attempt', data);
 };
 
-export const getPracticeResultApi = async (
-  practiceLogId: number,
-) => {
-  return await api.get(
-    `/api/practice/results/${practiceLogId}`,
-    {
-      withCredentials: true,
-    },
-  );
+export const getPracticeResultApi = async (practiceLogId: number) => {
+  return await api.get(`/api/practice/results/${practiceLogId}`);
 };
 
-export const getLatestPracticeLogApi =
-  async () => {
-    return await api.get(
-      "/api/practice/logs/latest",
-      {
-        withCredentials: true,
-      },
-    );
-  };
+export const getLatestPracticeLogApi = async () => {
+  return await api.get('/api/practice/logs/latest', {});
+};
 
-export const deletePracticeDetailApi = async (
-  detailId: number,
-) => {
-  return await api.delete(
-    `/api/practice/details/${detailId}`,
-    {
-      withCredentials: true,
-    },
-  );
+export const deletePracticeDetailApi = async (detailId: number) => {
+  return await api.delete(`/api/practice/details/${detailId}`);
 };


### PR DESCRIPTION
## 요약

수강신청 API 코드와 연습 모드(RegistrationPage) 코드 정리

## 구현 내용

- **registration.ts**: axios 인스턴스에 이미 설정된 `withCredentials`와 `headers` 중복 설정 제거
- **RegistrationPage.tsx**:
  - 여러 개의 ref (`timerRef`, `isPracticeRunningRef`, `startTimeRef`, `virtualOffsetRef`)를 단일 `practiceState` ref로 통합
  - 시작 시간 옵션 변환 로직을 `getTimeOption` 헬퍼 함수로 분리
  - 불필요한 `console.log` 제거
  - React Compiler 가이드라인에 맞게 불필요한 `useCallback` 제거
  - useEffect 클린업 함수의 ref 값 캡처 문제 수정

## 기술 노트

- React Compiler가 자동으로 메모이제이션을 처리하므로 `useCallback`/`useMemo` 불필요
- axios 인스턴스에 이미 Bearer 토큰 인터셉터와 기본 설정이 있으므로 각 API 호출에서 중복 설정 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)