### PR TITLE
[Fix] 리더보드 데이터 혼합 및 중복 표시 외 이슈 대응

### DIFF
--- a/src/features/leaderboard/model/useLeaderboardQuery.ts
+++ b/src/features/leaderboard/model/useLeaderboardQuery.ts
@@ -33,14 +33,15 @@ const getCategoryData = (data: LeaderboardResponse, category: CategoryType): Lea
 export function useLeaderboardInfiniteQuery(filter: FilterType, category: CategoryType) {
   return useInfiniteQuery({
     queryKey: leaderboardKeys.list(filter, category),
-    queryFn: async ({pageParam = 0}) => {
+    queryFn: async ({pageParam = 0, queryKey}) => {
+      const [, , filterParam, categoryParam] = queryKey;
       const response =
-        filter === 'all'
+        filterParam === 'all'
           ? await getLeaderboardApi({page: pageParam, size: PAGE_SIZE})
           : await getWeeklyLeaderboardApi({page: pageParam, size: PAGE_SIZE});
       return {
         fullData: response.data,
-        categoryData: getCategoryData(response.data, category),
+        categoryData: getCategoryData(response.data, categoryParam),
         page: pageParam,
       };
     },

--- a/src/features/registration-practice/model/usePracticeTimer.ts
+++ b/src/features/registration-practice/model/usePracticeTimer.ts
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
 import { practiceStartApi, practiceEndApi } from '../api/registrationApi';
+import { enrolledCoursesKeys } from './useEnrolledCoursesQuery';
 import type { VirtualStartTimeOption } from './types';
 
 export interface UsePracticeTimerOptions {
@@ -51,6 +53,7 @@ export function usePracticeTimer({
   closeWindow,
   onPracticeEnd,
 }: UsePracticeTimerOptions): UsePracticeTimerReturn {
+  const queryClient = useQueryClient();
   const [currentTime, setCurrentTime] = useState<Date>(createInitialTime);
   const [startOffset, setStartOffset] = useState<number>(0);
   const [isCooldown, setIsCooldown] = useState(false);
@@ -89,6 +92,7 @@ export function usePracticeTimer({
 
     try {
       await practiceEndApi();
+      queryClient.invalidateQueries({ queryKey: enrolledCoursesKeys.all });
       if (!isManual && onPracticeEnd) {
         onPracticeEnd();
       }

--- a/src/features/registration-practice/model/useRegistrationAttempt.ts
+++ b/src/features/registration-practice/model/useRegistrationAttempt.ts
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
 import { practiceAttemptApi } from '../api/registrationApi';
 import { calculateQueueInfo } from '../lib/registrationUtils';
+import { enrolledCoursesKeys } from './useEnrolledCoursesQuery';
 import type { WarningType } from '../ui/RegistrationWarning';
 import type { SelectedCourseInfo, WaitingInfo } from './types';
 
@@ -40,6 +42,7 @@ export function useRegistrationAttempt({
   onSelectionClear,
 }: UseRegistrationAttemptOptions): UseRegistrationAttemptReturn {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const [warningType, setWarningType] = useState<WarningType>('none');
   const [waitingInfo, setWaitingInfo] = useState<WaitingInfo | null>(null);
@@ -127,6 +130,7 @@ export function useRegistrationAttempt({
         onSelectionClear();
         setShowSuccessModal(true);
         setSucceededCourseIds((prev) => new Set(prev).add(currentCourseId));
+        queryClient.invalidateQueries({ queryKey: enrolledCoursesKeys.all });
       }
     } catch (error) {
       if (isAxiosError(error) && error.response) {

--- a/src/pages/leaderboard/index.tsx
+++ b/src/pages/leaderboard/index.tsx
@@ -75,7 +75,12 @@ export default function LeaderBoard() {
   };
 
   const entries: LeaderboardEntryResponse[] = data?.pages
-    ? data.pages.flatMap((page) => page.categoryData.items)
+    ? data.pages
+        .flatMap((page) => page.categoryData.items)
+        .filter(
+          (entry, index, self) =>
+            self.findIndex((e) => e.userId === entry.userId) === index
+        )
     : [];
 
   const getMyValue = (): { value: number | null; rank: number | null } => {

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,14 +1,20 @@
 import { useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { isAxiosError } from 'axios';
-import { useCourseSearchQuery, SearchCourseItem } from '@features/course-search';
+import {
+  useCourseSearchQuery,
+  SearchCourseItem,
+} from '@features/course-search';
 import { useAddToCartMutation, useCartQuery } from '@features/cart-management';
 import { useCaptcha } from '@features/registration-practice';
 import type { CourseDetailResponse } from '@entities/course';
 import { useModalStore } from '@shared/model/modalStore';
 import { WarningModal } from '@shared/ui/Warning';
 import { Pagination } from '@shared/ui/Pagination';
-import { hasTimeConflict, extractTimeFromPlaceAndTime } from '@shared/lib/timeUtils';
+import {
+  hasTimeConflict,
+  extractTimeFromPlaceAndTime,
+} from '@shared/lib/timeUtils';
 import './search.css';
 
 const PAGE_SIZE = 10;
@@ -21,11 +27,18 @@ export default function SearchPage() {
   const currentPage = parseInt(searchParams.get('page') || '0', 10);
 
   const captcha = useCaptcha();
-  const { openModal, closeModal, getData } = useModalStore();
+  const { openModal, closeModal } = useModalStore();
   const isCartOpen = useModalStore((s) => s.openModals.has('search/cart'));
-  const isConflictOpen = useModalStore((s) => s.openModals.has('search/conflict'));
-  const isNoCourseSelectedOpen = useModalStore((s) => s.openModals.has('search/noCourseSelected'));
-  const isTimeOverlapOpen = useModalStore((s) => s.openModals.has('search/timeOverlap'));
+  const isConflictOpen = useModalStore((s) =>
+    s.openModals.has('search/conflict')
+  );
+  const isNoCourseSelectedOpen = useModalStore((s) =>
+    s.openModals.has('search/noCourseSelected')
+  );
+  const isTimeOverlapOpen = useModalStore((s) =>
+    s.openModals.has('search/timeOverlap')
+  );
+
   const [selectedCourses, setSelectedCourses] = useState<Set<number>>(
     new Set()
   );
@@ -98,17 +111,7 @@ export default function SearchPage() {
       console.error('[Search] 장바구니 추가 실패:', err);
       if (isAxiosError(err) && err.response) {
         if (err.response.status === 409) {
-          const courseId = Array.from(selectedCourses)[0];
-          const course = courses.find(
-            (c: CourseDetailResponse) => c.id === courseId
-          );
-
-          if (course) {
-            openModal('search/conflict', {
-              name: course.courseTitle || '알 수 없는 강의',
-              code: course.courseNumber || '',
-            });
-          }
+          openModal('search/conflict');
           setSelectedCourses(new Set());
         } else {
           alert(
@@ -136,28 +139,17 @@ export default function SearchPage() {
         confirmLabel="장바구니로 이동"
       />
 
-      {getData('search/conflict') && (
-        <WarningModal.Confirm
-          isOpen={isConflictOpen}
-          onCancel={() => closeModal('search/conflict')}
-          onConfirm={() => {
-            closeModal('search/conflict');
-            navigate('/cart');
-          }}
-          cancelLabel="아니요, 괜찮습니다."
-          confirmLabel="장바구니로 이동"
-        >
-          <h2 className="modal-title-conflict">
-            {getData('search/conflict')!.name} ({getData('search/conflict')!.code}) :<br />
-            수업교시가 중복되었습니다.
-          </h2>
-          <p className="modal-subtitle">
-            지금 바로 장바구니로
-            <br />
-            이동하시겠습니까?
-          </p>
-        </WarningModal.Confirm>
-      )}
+      <WarningModal.Alert
+        isOpen={isConflictOpen}
+        onClose={() => closeModal('search/conflict')}
+        icon="warning"
+      >
+        <p className="warningText">
+          중복된 강의를 장바구니에
+          <br />
+          담을 수 없습니다.
+        </p>
+      </WarningModal.Alert>
 
       <WarningModal.Alert
         isOpen={isNoCourseSelectedOpen}

--- a/src/widgets/side-menu/SideMenu.tsx
+++ b/src/widgets/side-menu/SideMenu.tsx
@@ -87,6 +87,12 @@ export default function SideMenu({ isOpen, onClose, onLogout }: SideMenuProps) {
 
         {user && (
           <div className="sideMenuLogoutArea">
+            <button
+              className="sideMenuMypageBtn"
+              onClick={() => handleNavClick('/mypage', true)}
+            >
+              마이페이지
+            </button>
             <button className="sideMenuLogoutBtn" onClick={onLogout}>
               로그아웃
             </button>

--- a/src/widgets/side-menu/sideMenu.css
+++ b/src/widgets/side-menu/sideMenu.css
@@ -64,7 +64,18 @@
 
 /* Logout area */
 .sideMenuLogoutArea {
+  display: flex;
+  gap: 8px;
   padding: 0 24px 20px;
+}
+.sideMenuMypageBtn {
+  padding: 8px 20px;
+  border: 1px solid var(--blue);
+  border-radius: 6px;
+  background: #fff;
+  font-size: 14px;
+  color: var(--blue);
+  cursor: pointer;
 }
 .sideMenuLogoutBtn {
   padding: 8px 20px;


### PR DESCRIPTION
## 요약

리더보드 탭 빠른 전환 시 데이터가 뒤섞이는 문제(#87)와 특정 등수에서 사람이 중복 표시되는 문제를 포함하여, 수강신청내역·검색 페이지·사이드메뉴 관련 이슈를 수정합니다.

## 구현 내용

### 1. 리더보드 탭 전환 시 데이터 혼합 문제 해결 (#87)

**문제**: 1픽/2픽 탭을 빠르게 왔다갔다 하면 최상단에 다른 카테고리의 데이터가 섞여서 표시됨

**원인**: `useLeaderboardInfiniteQuery`의 `queryFn`이 `filter`와 `category`를 **컴포넌트 렌더 클로저**에서 캡처하고 있었음. 빠른 탭 전환 시 React의 Concurrent Rendering과 TanStack Query의 Observer 옵션 갱신 타이밍이 어긋나면서, queryFn의 클로저 변수가 실제 queryKey와 불일치하는 순간이 발생. 이로 인해 잘못된 카테고리 데이터가 잘못된 queryKey의 캐시에 저장됨.

**수정** (`useLeaderboardQuery.ts`):
```ts
// Before: 클로저 캡처 — race condition 발생 가능
queryFn: async ({pageParam = 0}) => {
  const response = filter === 'all' ? ... : ...;          // ← 클로저
  return { categoryData: getCategoryData(data, category) }; // ← 클로저
}

// After: queryKey context에서 추출 — 항상 정확한 값 보장
queryFn: async ({pageParam = 0, queryKey}) => {
  const [, , filterParam, categoryParam] = queryKey;
  const response = filterParam === 'all' ? ... : ...;
  return { categoryData: getCategoryData(data, categoryParam) };
}
```

TanStack Query가 특정 Query의 fetch를 실행할 때 `context.queryKey`에 해당 Query의 키를 담아 전달하므로, Observer 상태와 무관하게 항상 올바른 파라미터가 보장됩니다.

### 2. 리더보드 특정 등수 중복 표시 문제 해결

**문제**: 스크롤을 내리면 25등, 40등, 45등 등 특정 등수에서 같은 사람이 두 번 표시됨

**원인**: `data.pages.flatMap()`으로 모든 페이지를 단순 이어붙이기만 하고 중복 검사를 하지 않음. 백엔드의 오프셋 기반 페이지네이션에서 동점자가 페이지 경계에 걸릴 때 양쪽 페이지에 모두 포함될 수 있음.

**수정** (`pages/leaderboard/index.tsx`):
```ts
const entries = data?.pages
  .flatMap((page) => page.categoryData.items)
  .filter(
    (entry, index, self) =>
      self.findIndex((e) => e.userId === entry.userId) === index
  );
```

`userId` 기준으로 첫 번째 등장만 유지하여 중복을 제거합니다.

### 3. 수강신청내역 페이지 — 경쟁 없는 강의 자동 확정 표시

**수정** (`pages/enrollment-history/index.tsx`):
- 장바구니에서 `cartCount <= quota`인 강의(경쟁이 없어 자동 수강 확정되는 강의)를 수강신청내역에 병합하여 표시
- `enrolledData`와 `cartData`를 합치되, `enrolledIds` Set으로 중복 방지

### 4. 수강신청 성공/연습 종료 시 수강 목록 캐시 갱신

**수정** (`usePracticeTimer.ts`, `useRegistrationAttempt.ts`):
- `practiceEndApi()` 호출 후 `queryClient.invalidateQueries({ queryKey: enrolledCoursesKeys.all })` 추가
- 수강신청 성공 시에도 동일하게 enrolled courses 캐시 무효화
- 수강신청내역 페이지에서 최신 데이터가 즉시 반영됨

### 5. 검색 페이지 — 중복 강의 장바구니 추가 모달 개선

**수정** (`pages/search/index.tsx`):
- 409 응답(중복 강의) 시 `WarningModal.Confirm` → `WarningModal.Alert`로 변경
- 불필요한 `getData('search/conflict')` 의존성 제거
- 메시지를 "중복된 강의를 장바구니에 담을 수 없습니다."로 단순화

### 6. 모바일 사이드메뉴 — 마이페이지 버튼 추가

**수정** (`SideMenu.tsx`, `sideMenu.css`):
- 로그아웃 버튼 옆에 "마이페이지" 버튼 추가
- 파란색 outline 스타일로 로그아웃 버튼과 시각적 구분

## 엣지 케이스

- **리더보드 동점자**: 같은 점수의 유저가 페이지 경계에 걸려도 `userId` 기반 중복 제거로 한 번만 표시
- **수강신청내역 중복**: enrolled + cart 병합 시 `enrolledIds` Set으로 같은 강의가 두 번 표시되지 않도록 방어
- **빠른 탭 전환**: queryKey context 방식으로 어떤 타이밍에든 올바른 카테고리 데이터 보장

## 기술 노트

- `queryFn`의 클로저 캡처 대신 `context.queryKey` 디스트럭처링을 사용하는 것은 [TanStack Query 공식 권장 패턴](https://tanstack.com/query/latest/docs/framework/react/guides/query-functions#queryfunctioncontext)
- `filter + findIndex` 중복 제거는 O(n²)이지만, 리더보드 데이터가 최대 수백 건이므로 성능 이슈 없음
- enrolled courses 캐시 무효화에 `enrolledCoursesKeys.all`을 사용하여 관련 쿼리 전체를 갱신

Closes #87