### PR TITLE
도메인 마이그레이션: deploy dev/prod 분기 + API URL 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,16 @@
-name: CI/CD Team8 React App
+name: CI/CD SnuClear Web
 
 on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main
+      - dev
 
 jobs:
-  # 1. CI 작업 (검사 및 빌드 테스트)
   ci:
     runs-on: ubuntu-latest
     steps:
@@ -25,16 +26,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      # [중요] 코드 스타일 및 에러 검사
-      # package.json에 "lint" 명령어가 있어야 합니다.
       - name: Lint Code
         run: npm run lint
 
-      # (선택사항) 유닛 테스트가 있다면 주석을 풀고 사용하세요
-      # - name: Run Tests
-      #   run: npm run test
-
-      # 빌드가 정상적으로 되는지 미리 확인 (Type Check 포함)
       - name: Build Test
         run: npm run build
         env:
@@ -42,11 +36,11 @@ jobs:
           VITE_KAKAO_REST_API_KEY: ${{ secrets.VITE_KAKAO_REST_API_KEY }}
           VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
 
-  # 2. CD 작업 (배포) - CI가 성공해야만 실행됨
   deploy:
-    needs: ci # <--- [핵심] ci 작업이 성공해야만 deploy가 실행됩니다.
+    needs: ci
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' # PR일 땐 배포하지 않고, Push일 때만 배포
+    if: github.event_name == 'push'
+    environment: ${{ github.ref_name == 'main' && 'production' || 'development' }}
 
     steps:
       - name: Checkout source code

--- a/src/shared/api/axios.ts
+++ b/src/shared/api/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'https://snuclear.com/',
+  baseURL: import.meta.env.VITE_API_URL || 'https://snuclear-api.wafflestudio.com/',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'https://snuclear.com/',
+        target: 'https://snuclear-api.wafflestudio.com/',
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
## Summary
- `deploy.yml` dev/prod 환경 분기 (GitHub Environments 활용)
- API fallback URL → `snuclear-api.wafflestudio.com`
- vite proxy target 동일 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)