### PR TITLE
API 도메인을 snuclear-server로 변경

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ React 19 + Vite + TypeScript, FSD(Feature-Sliced Design) 아키텍처.
 - **상태관리**: TanStack Query 5, Zustand 5
 - **스타일**: CSS Modules (컴포넌트별 `.css` 파일)
 - **HTTP**: Axios (Bearer 토큰, sessionStorage에 저장)
-- **API 베이스**: `https://allclear.codes/` (개발 시 vite proxy `/api` 사용)
+- **API 베이스**: `https://snuclear-server.wafflestudio.com/` (개발 시 vite proxy `/api` 사용)
 
 ## 디렉토리 구조 (FSD)
 
@@ -42,7 +42,7 @@ npm run typecheck    # 타입 체크
 npm run build        # 프로덕션 빌드
 ```
 
-> **핸드폰 테스트**: 백엔드가 특정 IP만 허용하므로 `allclear.codes` 프로덕션에서 테스트.
+> **핸드폰 테스트**: 백엔드가 특정 IP만 허용하므로 `snuclear.wafflestudio.com` 프로덕션에서 테스트.
 > 롤백 필요 시 GitHub PR 페이지의 Revert 버튼 사용.
 
 ## 인증

--- a/src/shared/api/axios.ts
+++ b/src/shared/api/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'https://snuclear-api.wafflestudio.com/',
+  baseURL: import.meta.env.VITE_API_URL || 'https://snuclear-server.wafflestudio.com/',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'https://snuclear-api.wafflestudio.com/',
+        target: 'https://snuclear-server.wafflestudio.com/',
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
## 배경
- 인프라 마이그레이션으로 백엔드 도메인 네이밍 컨벤션이 `snuclear-api`에서 `snuclear-server`로 변경됨
- 프론트엔드가 기존 `snuclear-api.wafflestudio.com`으로 API를 보내고 있어 서버 연결 실패

## 변경사항
- axios baseURL fallback: `snuclear-api` → `snuclear-server`
- vite dev proxy target: `snuclear-api` → `snuclear-server`
- CLAUDE.md API 베이스 URL 업데이트