### PR TITLE
fix(home): 수강신청 기간 표 타이포그래피를 SNU와 동일하게

### DIFF
--- a/src/pages/home/home.css
+++ b/src/pages/home/home.css
@@ -171,14 +171,16 @@
     letter-spacing: -1px;
   }
   .periodTable td {
-    padding: 12px 5px;
+    padding: 10px 5px;
     border-bottom: none;
     vertical-align: middle;
     border-right: 1px solid #eef2f7;
-    font-size: 15px;
+    font-size: 16px;
     font-weight: 400;
-    letter-spacing: -0.6px;
+    letter-spacing: -1px;
+    line-height: 24px;
     white-space: pre-wrap;
+    word-break: keep-all;
   }
   .periodTable tbody tr.currentPeriod td {
     background-color: #eef5ff;
@@ -229,7 +231,9 @@
     padding: 0;
     font-size: 16px;
     font-weight: 400;
-    letter-spacing: -0.4px;
+    letter-spacing: -1px;
+    line-height: 24px;
+    word-break: keep-all;
     white-space: pre-wrap;
   }
 


### PR DESCRIPTION
## Summary
한글 단어가 중간에서 쪼개지는 어색한 줄바꿈 문제 수정. Playwright로 SNU 페이지와 비교하여 결정적 차이가 \`word-break\` 임을 확인, SNU 값으로 복제.

| 속성 | before | after (SNU 동일) |
|---|---|---|
| word-break | normal | **keep-all** |
| font-size | 15px | 16px |
| letter-spacing | -0.6px | -1px |
| line-height | normal | 24px |
| padding | 12px 5px | 10px 5px |

데스크탑/모바일 양쪽 td에 적용.

## Test plan
- [ ] 배포 후 https://snuclear.wafflestudio.com/ 메인 "대상" 칸에서 한글 단어 중간 줄바꿈 사라졌는지
- [ ] SNU 사이트와 시각적 비교

🤖 Generated with [Claude Code](https://claude.com/claude-code)