### PR TITLE
fix(home): 수강신청 기간 패널 SNU와 시각 매칭

### DIFF
--- a/src/pages/home/home.css
+++ b/src/pages/home/home.css
@@ -20,6 +20,13 @@
 }
 .periodPanel {
   order: 2;
+  background: transparent;
+  border-color: #c7d1de;
+  margin-bottom: 15px;
+  color: #333;
+  font-family: 'Noto Sans KR', Arial, Tahoma, sans-serif;
+  letter-spacing: -1px;
+  word-break: keep-all;
 }
 .rightButtons {
   order: 3;
@@ -93,16 +100,18 @@
   flex-wrap: wrap;
 }
 .periodTitle {
-  font-size: 19px;
+  font-size: 20px;
   font-weight: 600;
-  letter-spacing: -0.6px;
+  line-height: 26px;
+  letter-spacing: -1px;
 }
 .periodYear {
   color: var(--blue);
-  font-size: 19px;
+  font-size: 20px;
   font-weight: 600;
   margin-right: 6px;
-  letter-spacing: -0.6px;
+  line-height: 26px;
+  letter-spacing: -1px;
 }
 .periodBody {
   padding: 0 16px 20px;
@@ -122,11 +131,13 @@
 
 /* Desktop table layout */
 @media (min-width: 769px) {
-  .panelHead {
-    padding: 30px 36px 18px;
+  .periodPanel > .panelHead {
+    padding: 32px 40px 0;
+    margin: 0;
   }
-  .periodBody {
-    padding: 0 40px 30px;
+  .periodPanel > .periodBody {
+    padding: 0 40px 32px;
+    margin-top: 23px;
   }
 
   .periodTable,
@@ -153,22 +164,24 @@
     width: 25%;
   }
   .periodTable th:nth-child(2) {
-    width: 41%;
+    width: 40%;
   }
   .periodTable th:nth-child(3) {
-    width: 18%;
+    width: 19%;
   }
   .periodTable th:nth-child(4) {
     width: 16%;
   }
   .periodTable th {
-    padding: 14px 18px;
+    padding: 10px 5px;
     border-bottom: 1px solid #e5e7eb;
     border-right: 1px solid #eef2f7;
     font-size: 16px;
     font-weight: 400;
     text-align: center;
     letter-spacing: -1px;
+    line-height: 24px;
+    vertical-align: baseline;
   }
   .periodTable td {
     padding: 10px 5px;
@@ -183,11 +196,11 @@
     word-break: keep-all;
   }
   .periodTable tbody tr.currentPeriod td {
-    background-color: #eef5ff;
+    background-color: transparent;
   }
   .periodTable td:first-child {
     text-align: left;
-    padding-left: 18px;
+    padding-left: 15px;
   }
   .periodTable td:nth-child(2),
   .periodTable td:nth-child(3),

--- a/src/pages/home/home.css
+++ b/src/pages/home/home.css
@@ -194,9 +194,10 @@
     line-height: 24px;
     white-space: pre-wrap;
     word-break: keep-all;
+    overflow-wrap: break-word;
   }
   .periodTable tbody tr.currentPeriod td {
-    background-color: transparent;
+    background-color: #eef5ff;
   }
   .periodTable td:first-child {
     text-align: left;
@@ -247,6 +248,7 @@
     letter-spacing: -1px;
     line-height: 24px;
     word-break: keep-all;
+    overflow-wrap: break-word;
     white-space: pre-wrap;
   }
 


### PR DESCRIPTION
## Summary
Playwright로 SNU 패널의 computed style과 DOM 치수를 전부 비교한 뒤 주요 차이 반영.

- panel: bg transparent, border #c7d1de, margin-bottom 15px, color #333, font-family에 Arial/Tahoma fallback 추가
- panel 레벨: letter-spacing -1px, word-break keep-all 상속
- panelHead/periodBody padding을 SNU 내부 레이아웃(32px 40px 컨테이너 기준)과 동일하게
- 타이틀 19px → 20px, line-height 26px
- th padding 14px 18px → 10px 5px, line-height 24px, vertical-align baseline
- 시간 컬럼 18% → 19%
- td:first-child padding-left 18px → 15px
- td에 \`overflow-wrap: break-word\` 추가 — 긴 한글 단어(예: "정규학기수강취소)")가 셀 경계를 넘어 파란 배경 밖으로 튀어나오던 문제 수정

제외: 패널 전체 폭 (768 vs SNU 790)은 home 그리드 레이아웃 제약 (\`containerX\` max 1180 + 우측 380px). 내부 치수·스타일은 거의 일치 (td4 높이 261px 동일).

## Test plan
- [ ] 배포 후 https://snuclear.wafflestudio.com/ 메인 기간 패널 육안 확인
- [ ] 대상 칸 텍스트가 cell 경계(파란 배경) 안에 머무는지
- [ ] 타이포그래피(제목 20px, 표 line-height 24px) SNU와 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)