### PR TITLE
feat(auth): URL 라우트 가드 + admin 강제 리다이렉트 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,14 @@ npm run build        # 프로덕션 빌드
 - `src/shared/api/fetch.ts`에서 요청 시 자동 첨부
 - 토큰은 탭/브라우저 세션 단위로 유지 (창 닫으면 만료)
 
+### 라우트 가드
+
+`src/features/auth/ui/` 의 컴포넌트로 라우트 레벨 보호. 비권한 시 `/`로 리다이렉트.
+- `<RequireAuth>` — 로그인 필요 (`/cart`, `/registration`, `/enrollment-history`, `/mypage`, `/practice-results`, `/practice-session/:id`)
+- `<RequireAdmin>` — 어드민 권한 필요 (`/admin`)
+
+어드민 유저도 일반 페이지 자유 접근 가능 (AuthProvider에서 강제 리다이렉트 제거됨).
+
 ## QR 공유 기능 (session-share)
 
 - `src/pages/practice-session/index.tsx`: 세션 데이터를 base64 인코딩 → QR 생성 (`qrcode` 라이브러리)

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -8,7 +8,6 @@ const MAX_LOGIN_TIME = 10 * 60;
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const queryClient = useQueryClient();
-  const location = useLocation();
   const [user, setUser] = useState<User | null>(() => {
     const storedUser = sessionStorage.getItem('userInfo');
     if (!storedUser) return null;
@@ -19,19 +18,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return null;
     }
   });
-
-  // 권한에 따른 페이지 접근 제어
-  useEffect(() => {
-    const isAdminPath = location.pathname.startsWith('/admin');
-
-    if (user?.admin && !isAdminPath) {
-      // 관리자가 일반 페이지 접근 시 어드민 페이지로 리다이렉트
-      window.location.replace('/admin');
-    } else if (!user?.admin && isAdminPath) {
-      // 비관리자가 어드민 페이지 접근 시 홈으로 리다이렉트
-      window.location.replace('/');
-    }
-  }, [user, location.pathname]);
 
   const login = (userData: User, accessToken: string) => {
     setUser(userData);

--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -14,6 +14,7 @@ import AdminPage from '@pages/admin';
 import NoticesPage from '@pages/notices';
 import NoticeDetailPage from '@pages/notices/NoticeDetailPage';
 import SessionSharePage from '@pages/session-share';
+import { RequireAuth, RequireAdmin } from '@features/auth';
 
 export function AppRoutes() {
   return (
@@ -22,17 +23,63 @@ export function AppRoutes() {
       <Route path="/login" element={<Login />} />
       <Route path="/register" element={<Register />} />
       <Route path="/search" element={<SearchPage />} />
-      <Route path="/cart" element={<Cart />} />
-      <Route path="/registration" element={<Registration />} />
-      <Route path="/enrollment-history" element={<EnrollmentHistory />} />
+      <Route
+        path="/cart"
+        element={
+          <RequireAuth>
+            <Cart />
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/registration"
+        element={
+          <RequireAuth>
+            <Registration />
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/enrollment-history"
+        element={
+          <RequireAuth>
+            <EnrollmentHistory />
+          </RequireAuth>
+        }
+      />
       <Route path="/leaderboard" element={<LeaderBoard />} />
-      <Route path="/mypage" element={<MyPage />} />
-      <Route path="/practice-results" element={<PracticeResults />} />
+      <Route
+        path="/mypage"
+        element={
+          <RequireAuth>
+            <MyPage />
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/practice-results"
+        element={
+          <RequireAuth>
+            <PracticeResults />
+          </RequireAuth>
+        }
+      />
       <Route
         path="/practice-session/:sessionId"
-        element={<PracticeSessionDetail />}
+        element={
+          <RequireAuth>
+            <PracticeSessionDetail />
+          </RequireAuth>
+        }
       />
-      <Route path="/admin" element={<AdminPage />} />
+      <Route
+        path="/admin"
+        element={
+          <RequireAdmin>
+            <AdminPage />
+          </RequireAdmin>
+        }
+      />
       <Route path="/notices" element={<NoticesPage />} />
       <Route path="/notices/:noticeId" element={<NoticeDetailPage />} />
       <Route path="/session-share" element={<SessionSharePage />} />

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,6 +1,9 @@
 export { AuthContext, useAuth } from './model/authContext';
 export type { User, AuthContextType, LoginProvider } from './model/authContext';
 
+export { RequireAuth } from './ui/RequireAuth';
+export { RequireAdmin } from './ui/RequireAdmin';
+
 export { TimerContext, useTimer } from './model/timerContext';
 export type { TimerContextType } from './model/timerContext';
 

--- a/src/features/auth/ui/RequireAdmin.tsx
+++ b/src/features/auth/ui/RequireAdmin.tsx
@@ -1,0 +1,8 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../model/authContext';
+
+export function RequireAdmin({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  if (!user?.admin) return <Navigate to="/" replace />;
+  return <>{children}</>;
+}

--- a/src/features/auth/ui/RequireAuth.tsx
+++ b/src/features/auth/ui/RequireAuth.tsx
@@ -1,0 +1,8 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../model/authContext';
+
+export function RequireAuth({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  if (!user) return <Navigate to="/" replace />;
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- \`RequireAuth\`, \`RequireAdmin\` 가드 컴포넌트 추가 (\`src/features/auth/ui/\`)
- 보호 페이지 6개에 \`RequireAuth\` 적용 → 비로그인 URL 직접 접근 시 \`/\`로 리다이렉트
- \`/admin\`에 \`RequireAdmin\` 적용 → 비어드민 접근 시 \`/\`로 리다이렉트
- AuthProvider의 admin 강제 리다이렉트 useEffect 제거
  → 어드민 유저도 일반 페이지 자유 이동 가능

## Behavior matrix
| 시나리오 | 이전 | 이후 |
|---|---|---|
| 비로그인 유저가 /cart URL 접근 | 빈 껍데기 렌더 (401) | **/** |
| 비로그인 유저가 /admin URL 접근 | window.location.replace('/') | **/** (Navigate) |
| 일반 유저가 /admin URL 접근 | window.location.replace('/') | **/** (Navigate) |
| 어드민이 / URL 접근 | window.location.replace('/admin') (강제) | **/** (자유) |
| 어드민이 /cart 접근 | 강제 /admin으로 | **/cart** 그대로 |

## 유지
- 헤더의 "로그인 후 사용할 수 있는 기능입니다" 모달 (네비 4개 버튼 클릭 시 트리거)
- 로그인 직후 어드민은 /admin으로 랜딩 (login 페이지 로직)

## Test plan
- [ ] 비로그인 상태로 /cart 등 6개 URL 직접 접근 → /로 이동 확인
- [ ] 일반 유저로 /admin 접근 → /로 이동 확인
- [ ] 어드민이 /admin에서 로고/뒤로가기로 다른 페이지 이동 가능 확인
- [ ] 헤더 모달이 여전히 나타나는지 (비로그인 + 장바구니 버튼 클릭)

🤖 Generated with [Claude Code](https://claude.com/claude-code)